### PR TITLE
If the blog post author left width tags in his/her HTML, still make s…

### DIFF
--- a/Evergreen/Resources/styleSheet.css
+++ b/Evergreen/Resources/styleSheet.css
@@ -48,6 +48,7 @@ pre  {
 }
 img {
 	max-width: 100%;
+	height: auto;
 }
 
 /*Block ads and junk*/


### PR DESCRIPTION
If the blog post author left width tags in his/her HTML, still make sure the image shows its original aspect.

Before and after:

<img width="1510" alt="screen shot 2017-06-01 at 21 37 23" src="https://cloud.githubusercontent.com/assets/12690/26697501/982c509e-4712-11e7-8d57-0586656e31d3.png">

<img width="1552" alt="screen shot 2017-06-01 at 21 35 16" src="https://cloud.githubusercontent.com/assets/12690/26697500/98277664-4712-11e7-99a2-3bb47e54aba3.png">