### PR TITLE
Share button now supports "EagleFiler Import" and "Add to Reading List".

### DIFF
--- a/Evergreen/MainWindow/Timeline/ArticlePasteboardWriter.swift
+++ b/Evergreen/MainWindow/Timeline/ArticlePasteboardWriter.swift
@@ -31,12 +31,12 @@ import Data
 
 	func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
 
-		var types = [ArticlePasteboardWriter.articleUTIType, .string]
+		var types = [ArticlePasteboardWriter.articleUTIType]
 
 		if let link = article.preferredLink, let _ = URL(string: link) {
 			types += [.URL]
 		}
-		types += [.html, ArticlePasteboardWriter.articleUTIInternalType]
+		types += [.string, .html, ArticlePasteboardWriter.articleUTIInternalType]
 
 		return types
 	}


### PR DESCRIPTION
List .URL before .string in the pasteboard types because otherwise the system will not propose sharing services that receive URLs but not text.