### PR TITLE
Fix type optionality of makeToolbarValidate's sender parameter

### DIFF
--- a/Evergreen/MainWindow/MainWindowController.swift
+++ b/Evergreen/MainWindow/MainWindowController.swift
@@ -113,7 +113,7 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 
 	// MARK: Toolbar
 	
-	@objc func makeToolbarValidate(_ sender: Any) {
+	@objc func makeToolbarValidate(_ sender: Any?) {
 		
 		window?.toolbar?.validateVisibleItems()
 	}


### PR DESCRIPTION
Sender should be Any? to reflect the fact it may be nil. This nuance seems to make the difference on Xcode 9.3/Swift 4.1 between crashing or not. Without this change, refreshing crashes every time, presumably because Swift is making assumptions about the parameter being non-nil and refreshProgressDidChange calls it explicitly with a nil parameter.