### PR TITLE
Support for  ‘permalink’ and ‘external url’ properties of 'article'

### DIFF
--- a/Evergreen.xcodeproj/project.pbxproj
+++ b/Evergreen.xcodeproj/project.pbxproj
@@ -168,6 +168,17 @@
 		D5D1751220020B980047B29D /* Evergreen.sdef in Resources */ = {isa = PBXBuildFile; fileRef = D5D175012002039D0047B29D /* Evergreen.sdef */; };
 		D5E4CC54202C1361009B4FFC /* AppDelegate+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */; };
 		D5E4CC64202C1AC1009B4FFC /* MainWindowController+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */; };
+		D5E4CCB320300024009B4FFC /* uiScriptingTestSetup.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CCB220300024009B4FFC /* uiScriptingTestSetup.applescript */; };
+		D5E4CCB420300033009B4FFC /* uiScriptingTestSetup.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCB220300024009B4FFC /* uiScriptingTestSetup.applescript */; };
+		D5E4CCC520300537009B4FFC /* AppleScriptXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CCC3203004EA009B4FFC /* AppleScriptXCTestCase.swift */; };
+		D5E4CCD720303823009B4FFC /* selectAnArticle.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CCD520303823009B4FFC /* selectAnArticle.applescript */; };
+		D5E4CCD820303823009B4FFC /* selectAFeed.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CCD620303823009B4FFC /* selectAFeed.applescript */; };
+		D5E4CCDA2030382A009B4FFC /* establishMainWindowStartingState.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CCD92030382A009B4FFC /* establishMainWindowStartingState.applescript */; };
+		D5E4CCDB20303A52009B4FFC /* selectAFeed.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCD620303823009B4FFC /* selectAFeed.applescript */; };
+		D5E4CCDC20303A52009B4FFC /* selectAnArticle.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCD520303823009B4FFC /* selectAnArticle.applescript */; };
+		D5E4CCDD20303A59009B4FFC /* establishMainWindowStartingState.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCD92030382A009B4FFC /* establishMainWindowStartingState.applescript */; };
+		D5E4CCDE20303A66009B4FFC /* testCurrentArticleIsNil.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCD12030260E009B4FFC /* testCurrentArticleIsNil.applescript */; };
+		D5E4CCDF20303A66009B4FFC /* testURLsOfCurrentArticle.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5E4CCCF203025FF009B4FFC /* testURLsOfCurrentArticle.applescript */; };
 		D5F4EDB5200744A700B9E363 /* ScriptingObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */; };
 		D5F4EDB720074D6500B9E363 /* Feed+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */; };
 		D5F4EDB920074D7C00B9E363 /* Folder+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */; };
@@ -482,6 +493,12 @@
 			dstPath = TestScripts;
 			dstSubfolderSpec = 7;
 			files = (
+				D5E4CCDE20303A66009B4FFC /* testCurrentArticleIsNil.applescript in CopyFiles */,
+				D5E4CCDF20303A66009B4FFC /* testURLsOfCurrentArticle.applescript in CopyFiles */,
+				D5E4CCDD20303A59009B4FFC /* establishMainWindowStartingState.applescript in CopyFiles */,
+				D5E4CCDB20303A52009B4FFC /* selectAFeed.applescript in CopyFiles */,
+				D5E4CCDC20303A52009B4FFC /* selectAnArticle.applescript in CopyFiles */,
+				D5E4CCB420300033009B4FFC /* uiScriptingTestSetup.applescript in CopyFiles */,
 				D5A267C220131BA000A8D3C0 /* testFeedOPML.applescript in CopyFiles */,
 				D5A2679D201313A200A8D3C0 /* testNameOfAuthors.applescript in CopyFiles */,
 				D5F4EDE920075C6700B9E363 /* testNameAndUrlOfEveryFeed.applescript in CopyFiles */,
@@ -658,6 +675,13 @@
 		D5D175012002039D0047B29D /* Evergreen.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = Evergreen.sdef; path = ../Resources/Evergreen.sdef; sourceTree = "<group>"; };
 		D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Scriptability.swift"; sourceTree = "<group>"; };
 		D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainWindowController+Scriptability.swift"; sourceTree = "<group>"; };
+		D5E4CCB220300024009B4FFC /* uiScriptingTestSetup.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = uiScriptingTestSetup.applescript; sourceTree = "<group>"; };
+		D5E4CCC3203004EA009B4FFC /* AppleScriptXCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppleScriptXCTestCase.swift; path = EvergreenTests/ScriptingTests/AppleScriptXCTestCase.swift; sourceTree = SOURCE_ROOT; };
+		D5E4CCCF203025FF009B4FFC /* testURLsOfCurrentArticle.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testURLsOfCurrentArticle.applescript; sourceTree = "<group>"; };
+		D5E4CCD12030260E009B4FFC /* testCurrentArticleIsNil.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testCurrentArticleIsNil.applescript; sourceTree = "<group>"; };
+		D5E4CCD520303823009B4FFC /* selectAnArticle.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = selectAnArticle.applescript; sourceTree = "<group>"; };
+		D5E4CCD620303823009B4FFC /* selectAFeed.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = selectAFeed.applescript; sourceTree = "<group>"; };
+		D5E4CCD92030382A009B4FFC /* establishMainWindowStartingState.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = establishMainWindowStartingState.applescript; sourceTree = "<group>"; };
 		D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptingObject.swift; sourceTree = "<group>"; };
 		D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feed+Scriptability.swift"; sourceTree = "<group>"; };
 		D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Scriptability.swift"; sourceTree = "<group>"; };
@@ -1272,6 +1296,7 @@
 			children = (
 				D5558FCF20021C590066386B /* scripts */,
 				D5558FD22002245C0066386B /* ScriptingTests.swift */,
+				D5E4CCC3203004EA009B4FFC /* AppleScriptXCTestCase.swift */,
 			);
 			path = ScriptingTests;
 			sourceTree = "<group>";
@@ -1279,6 +1304,9 @@
 		D5558FCF20021C590066386B /* scripts */ = {
 			isa = PBXGroup;
 			children = (
+				D5E4CCD92030382A009B4FFC /* establishMainWindowStartingState.applescript */,
+				D5E4CCD620303823009B4FFC /* selectAFeed.applescript */,
+				D5E4CCD520303823009B4FFC /* selectAnArticle.applescript */,
 				D5907C9D20023249005947E5 /* testGenericScript.applescript */,
 				D5A267B220131B8300A8D3C0 /* testFeedOPML.applescript */,
 				D5558FD1200223F60066386B /* testGetURL.applescript */,
@@ -1286,6 +1314,9 @@
 				D5A2679B201312F900A8D3C0 /* testNameOfAuthors.applescript */,
 				D5F4EDD720075C1300B9E363 /* testNameOfEveryFolder.applescript */,
 				D55373A02018797B006D8857 /* testTitleOfArticlesWhose.applescript */,
+				D5E4CCD12030260E009B4FFC /* testCurrentArticleIsNil.applescript */,
+				D5E4CCCF203025FF009B4FFC /* testURLsOfCurrentArticle.applescript */,
+				D5E4CCB220300024009B4FFC /* uiScriptingTestSetup.applescript */,
 			);
 			path = scripts;
 			sourceTree = "<group>";
@@ -1940,10 +1971,15 @@
 				D5A267C120131B8300A8D3C0 /* testFeedOPML.applescript in Sources */,
 				D5A2679C201312F900A8D3C0 /* testNameOfAuthors.applescript in Sources */,
 				849C64761ED37A5D003D8FC0 /* EvergreenTests.swift in Sources */,
+				D5E4CCC520300537009B4FFC /* AppleScriptXCTestCase.swift in Sources */,
+				D5E4CCB320300024009B4FFC /* uiScriptingTestSetup.applescript in Sources */,
 				D5558FD32002245C0066386B /* ScriptingTests.swift in Sources */,
+				D5E4CCDA2030382A009B4FFC /* establishMainWindowStartingState.applescript in Sources */,
 				D5F4EDE820075C1800B9E363 /* testNameAndUrlOfEveryFeed.applescript in Sources */,
 				D5907CA0200232A1005947E5 /* testGenericScript.applescript in Sources */,
 				D5F4EDE620075C1300B9E363 /* testNameOfEveryFolder.applescript in Sources */,
+				D5E4CCD720303823009B4FFC /* selectAnArticle.applescript in Sources */,
+				D5E4CCD820303823009B4FFC /* selectAFeed.applescript in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Evergreen/AppDelegate.swift
+++ b/Evergreen/AppDelegate.swift
@@ -139,9 +139,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		feedIconDownloader = FeedIconDownloader(imageDownloader: imageDownloader)
 
 		updateSortMenuItems()
-		createAndShowMainWindow()
-
-		NSAppleEventManager.shared().setEventHandler(self, andSelector: #selector(AppDelegate.getURL(_:_:)), forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
+        createAndShowMainWindow()
+        installAppleEventHandlers()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(feedSettingDidChange(_:)), name: .FeedSettingDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(userDefaultsDidChange(_:)), name: UserDefaults.didChangeNotification, object: nil)
@@ -183,25 +182,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 	func applicationWillTerminate(_ notification: Notification) {
 
 		saveState()
-	}
-
-	// MARK: GetURL Apple Event
-
-	@objc func getURL(_ event: NSAppleEventDescriptor, _ withReplyEvent: NSAppleEventDescriptor) {
-
-		guard let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue else {
-			return
-		}
-
-		let normalizedURLString = urlString.rs_normalizedURL()
-		if !normalizedURLString.rs_stringMayBeURL() {
-			return
-		}
-
-		DispatchQueue.main.async {
-
-			self.addFeed(normalizedURLString)
-		}
 	}
 
 	// MARK: Notifications

--- a/Evergreen/Resources/Evergreen.sdef
+++ b/Evergreen/Resources/Evergreen.sdef
@@ -6,6 +6,13 @@
 <dictionary title="sa;lfsdf" xmlns:xi="http://www.w3.org/2003/XInclude">
     
     <suite name="Standard Suite" code="core" description="Subset of the Standard Suite.">
+        <access-group identifier="com.ranchero.Evergreen" access="rw"/>
+        <command name="exists" code="coredoex" description="Verify that an object exists.">
+            <cocoa class="Evergreen.EvergreenExistsCommand"/>
+            <direct-parameter type="any" requires-access="r" description="The object(s) to check."/>
+            <result type="boolean" description="Does the object(s) exist?"/>
+        </command>
+
         <class name="application" code="capp" description="The application's top-level scripting object.">
             <cocoa class="NSApplication"/>
             <property name="name" code="pnam" type="text" access="r" description="The name of the application."/>
@@ -14,6 +21,7 @@
     </suite>
 
     <suite name="Evergreen Suite" code="Geod" description="The Evergreen Application Suite.">
+        <access-group identifier="com.ranchero.Evergreen" access="rw"/>
         <class name="application" code="capp"
              description="Evergreen Application" inherits="application">
              
@@ -142,8 +150,14 @@
             <property name="title" code="titl" type="text" access="r" description="The article title">
                 <cocoa key="title"/>
             </property>
-            <property name="url" code="URL " type="text" access="r" description="url for the article">
+            <property name="url" code="URL " type="text" access="r" description="url for the article.  This will be the permalink if available, or the external url">
                 <cocoa key="url"/>
+            </property>
+            <property name="external url" code="eURL" type="text" access="r" description="the external url for the article, if known">
+                <cocoa key="externalUrl"/>
+            </property>
+            <property name="permalink" code="pLnk" type="text" access="r" description="a permalink for the article, if known">
+                <cocoa key="permalink"/>
             </property>
             <property name="contents" code="Cnts" type="text" access="r" description="text of the article">
                 <cocoa key="contents"/>
@@ -182,9 +196,9 @@
 
     </suite>
 
-    <suite name="Internet Suite" code="GURL"
-        description="Standard Internet Suite.">
-        
+    <suite name="Internet Suite" code="GURL" description="Standard Internet Suite.">
+        <access-group identifier="com.ranchero.Evergreen" access="rw"/>
+
         <command name="open location" code="GURLGURL" description="opens the given url.">
             <direct-parameter type="text"/>
         </command>        

--- a/Evergreen/Scriptability/AppDelegate+Scriptability.swift
+++ b/Evergreen/Scriptability/AppDelegate+Scriptability.swift
@@ -19,10 +19,60 @@
 import Foundation
 import Data
 
+protocol AppDelegateAppleEvents {
+    func installAppleEventHandlers()
+    func getURL(_ event: NSAppleEventDescriptor, _ withReplyEvent: NSAppleEventDescriptor)
+}
+
 protocol ScriptingAppDelegate {
     var  scriptingCurrentArticle: Article?  {get}
     var  scriptingSelectedArticles: [Article]  {get}
     var  scriptingMainWindowController:ScriptingMainWindowController? {get}
 }
 
+extension AppDelegate : AppDelegateAppleEvents {
+    
+    // MARK: GetURL Apple Event
+
+    func installAppleEventHandlers() {
+        NSAppleEventManager.shared().setEventHandler(self, andSelector: #selector(AppDelegate.getURL(_:_:)), forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
+    }
+    
+    @objc func getURL(_ event: NSAppleEventDescriptor, _ withReplyEvent: NSAppleEventDescriptor) {
+
+        guard let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue else {
+            return
+        }
+
+        let normalizedURLString = urlString.rs_normalizedURL()
+        if !normalizedURLString.rs_stringMayBeURL() {
+            return
+        }
+
+        DispatchQueue.main.async {
+
+            self.addFeed(normalizedURLString)
+        }
+    }
+}
+
+class EvergreenExistsCommand : NSExistsCommand {
+    
+    // cocoa default behavior doesn't work here, because of cases where we define an object's property
+    // to be another object type.  e.g., 'permalink of the current article' parses as
+    //    <property> of <property> of <top level object>
+    // cocoa would send the top level object (the app) a doesExist message for a nested property, and
+    // it errors out because it doesn't know how to handle that
+    // What we do instead is simply see if the defaultImplementation errors, and if it does, the object
+    // must not exist.  Otherwise, we return the result of the defaultImplementation
+    // The wrinkle is that it is possible that the direct object is a list, so we need to
+    // handle that case as well
+    
+    override func performDefaultImplementation() -> Any? {
+         guard let result = super.performDefaultImplementation() else { return NSNumber(booleanLiteral:false) }
+         return result
+        // return NSNumber(booleanLiteral:true)
+         //  scriptingContainer.handleDoObjectsExist(command:self)
+    }
+}
 

--- a/Evergreen/Scriptability/Article+Scriptability.swift
+++ b/Evergreen/Scriptability/Article+Scriptability.swift
@@ -51,10 +51,20 @@ class ScriptableArticle: NSObject, UniqueIdScriptingObject, ScriptingObjectConta
     // MARK: --- Scriptable properties ---
     
     @objc(url)
-    var url:String  {
-        return article.url ?? ""
+    var url:String?  {
+        return article.url ?? article.externalURL
     }
-    
+
+    @objc(permalink)
+    var permalink:String?  {
+        return article.url
+    }
+
+    @objc(externalUrl)
+    var externalUrl:String?  {
+        return article.externalURL
+    }
+
     @objc(uniqueId)
     var uniqueId:String  {
         return article.uniqueID

--- a/Evergreen/Scriptability/ScriptingObjectContainer.swift
+++ b/Evergreen/Scriptability/ScriptingObjectContainer.swift
@@ -12,9 +12,8 @@ protocol ScriptingObjectContainer: ScriptingObject {
     var scriptingClassDescription:NSScriptClassDescription { get }
 }
 
-
 extension ScriptingObjectContainer {
-    
+
     func makeFormNameScriptObjectSpecifier(forObject object:NamedScriptingObject) -> NSScriptObjectSpecifier? {
         let containerClassDescription = self.scriptingClassDescription
         let containerScriptObjectSpecifier = self.objectSpecifier

--- a/EvergreenTests/ScriptingTests/AppleScriptXCTestCase.swift
+++ b/EvergreenTests/ScriptingTests/AppleScriptXCTestCase.swift
@@ -1,0 +1,67 @@
+//
+//  AppleScriptXCTestCase.swift
+//  EvergreenUITests
+//
+//  Created by Olof Hellman on 2/10/18.
+//  Copyright © 2018 Ranchero Software. All rights reserved.
+//
+
+import XCTest
+
+class AppleScriptXCTestCase: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    /*
+        @function doIndividualScript
+        @param filename -- name of a .applescript (sans extention) in the test bundle's
+                           Resources/TestScripts directory
+        @brief  given a file, loads the script and runs it.  Expects a result from running
+                the script of the form
+                     {test_result:true, script_result:<anything>}
+                if the test_result is false or is missing, the test fails
+        @return  the value of script_result, if any
+    */
+    func doIndividualScript(filename:String) -> NSAppleEventDescriptor? {
+        var errorDict: NSDictionary? = nil
+        let testBundle = Bundle(for: type(of: self))
+        let url = testBundle.url(forResource:filename, withExtension:"applescript", subdirectory:"TestScripts")
+        guard let testScriptUrl = url  else {
+            XCTFail("Failed Getting script URL")
+            return nil
+        }
+        
+        guard let testScript = NSAppleScript(contentsOf: testScriptUrl, error: &errorDict) else {
+            print ("error is \(String(describing: errorDict))")
+            XCTFail("Failed initializing NSAppleScript")
+            return nil
+        }
+        
+        let scriptResult = testScript.executeAndReturnError(&errorDict)
+        if (errorDict != nil) {
+            print ("error is \(String(describing: errorDict))")
+            XCTFail("Failed executing script")
+            return nil
+        }
+        
+        let usrfDictionary = scriptResult.usrfDictionary()
+        guard let testResult = usrfDictionary["test_result"] else {
+            XCTFail("test script didn't return test result in usrf")
+            return nil
+        }
+        
+        if (testResult.booleanValue != true) {
+            print("test_result was \(testResult)")
+            print("script_result was \(String(describing: usrfDictionary["script_result"]))")
+        }
+        
+        XCTAssert(testResult.booleanValue == true, "test_result should be true")
+        return usrfDictionary["script_result"]
+    }
+}

--- a/EvergreenTests/ScriptingTests/scripts/establishMainWindowStartingState.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/establishMainWindowStartingState.applescript
@@ -1,0 +1,37 @@
+property uparrowKeyCode : 126
+property downarrowKeyCode : 125
+property rightarrowKeyCode : 124
+property leftarrowKeyCode : 123
+
+to activateEvergreen()
+	tell application "Evergreen"
+		activate
+	end tell
+end activateEvergreen
+
+to multipleKeyCodes(keycode, numberOfKeys)
+	tell application "System Events"
+		tell process "Evergreen"
+			repeat numberOfKeys times
+				key code keycode
+			end repeat
+		end tell
+	end tell
+end multipleKeyCodes
+
+to establishMainWindowStartingState()
+	activateEvergreen()
+	multipleKeyCodes(downarrowKeyCode, 2)
+	multipleKeyCodes(rightarrowKeyCode, 2)
+	multipleKeyCodes(leftarrowKeyCode, 2)
+	multipleKeyCodes(uparrowKeyCode, 50)
+end establishMainWindowStartingState
+
+try
+	establishMainWindowStartingState()
+	-- hit the down arrow a few times to get into the feeds
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:true, script_result:"established starting state"}

--- a/EvergreenTests/ScriptingTests/scripts/selectAFeed.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/selectAFeed.applescript
@@ -1,0 +1,32 @@
+
+
+property uparrowKeyCode : 126
+property downarrowKeyCode : 125
+property rightarrowKeyCode : 124
+property leftarrowKeyCode : 123
+
+to activateEvergreen()
+	tell application "Evergreen"
+		activate
+	end tell
+end activateEvergreen
+
+to multipleKeyCodes(keycode, numberOfKeys)
+	tell application "System Events"
+		tell process "Evergreen"
+			repeat numberOfKeys times
+				key code keycode
+			end repeat
+		end tell
+	end tell
+end multipleKeyCodes
+
+try
+    activateEvergreen()
+	multipleKeyCodes(downarrowKeyCode, 9)
+	multipleKeyCodes(uparrowKeyCode, 1)	
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:true, script_result:"selected feed"}

--- a/EvergreenTests/ScriptingTests/scripts/selectAnArticle.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/selectAnArticle.applescript
@@ -1,0 +1,31 @@
+
+
+property uparrowKeyCode : 126
+property downarrowKeyCode : 125
+property rightarrowKeyCode : 124
+property leftarrowKeyCode : 123
+
+to activateEvergreen()
+	tell application "Evergreen"
+		activate
+	end tell
+end activateEvergreen
+
+to multipleKeyCodes(keycode, numberOfKeys)
+	tell application "System Events"
+		tell process "Evergreen"
+			repeat numberOfKeys times
+				key code keycode
+			end repeat
+		end tell
+	end tell
+end multipleKeyCodes
+
+try
+    activateEvergreen()
+	multipleKeyCodes(rightarrowKeyCode, 1)
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:true, script_result:"selected an article"}

--- a/EvergreenTests/ScriptingTests/scripts/testCurrentArticleIsNil.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/testCurrentArticleIsNil.applescript
@@ -1,0 +1,23 @@
+-- this script   tests that it is possible to get the url property of the current article
+-- it uses system event accessibility scripting to set up the main window
+-- one needs to authorize scripting accessibility control in the System Preferences'
+--  Privacy and security pane
+
+try
+    tell application "Evergreen"
+        set shouldBeMissingValue to current article
+    end tell
+
+    --verify that the current article is in fact 'missing vcalue'
+    if shouldBeMissingValue is missing value then
+        set the_message to "passed tests"
+        set the_result to true
+    else
+        set the_message to "expected current article to be 'missing value'"
+        set the_result to false
+    end if
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:the_result, script_result:the_message}

--- a/EvergreenTests/ScriptingTests/scripts/testURLsOfCurrentArticle.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/testURLsOfCurrentArticle.applescript
@@ -1,0 +1,14 @@
+-- this script   tests that it is possible to get the url property of the current article
+-- it uses system event accessibility scripting to set up the main window
+-- one needs to authorize scripting accessibility control in the System Preferences'
+--  Privacy and security pane
+
+try
+    tell application "Evergreen"
+        {url, permalink, external url} of current article
+    end tell
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:true, script_result:"tests passed"}

--- a/EvergreenTests/ScriptingTests/scripts/uiScriptingTestSetup.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/uiScriptingTestSetup.applescript
@@ -1,0 +1,18 @@
+-- this script sets up Evergreen so it is ready to be tested
+-- to get a current article
+
+to activateEvergreen()
+	tell application "Evergreen"
+		activate
+	end tell
+end activateEvergreen
+
+tell application "System Events"
+	set isFrontmost to frontmost of process "Evergreen"
+	repeat while isFrontmost is false
+		my activateEvergreen()
+		set isFrontmost to frontmost of process "Evergreen"
+	end repeat
+end tell
+
+return {test_result:true, script_result:"finished"}


### PR DESCRIPTION
Add ‘permalink’ and ‘external url’ properties to the article scripting object
Add exists command
Consolidate GetURL AppleEvent handling into AppDelegate+Scriptability file
Add scripting access groups to sdef
Add a unit test to verify the behavior of ‘current article’ 
