### PR TITLE
Add a CFBundleURLType, Better logic for rs_normalizedURLString, Add testFeedExistsScript, remove redundant code

### DIFF
--- a/Evergreen.xcodeproj/project.pbxproj
+++ b/Evergreen.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		D5558FD5200225680066386B /* NSAppleEventDescriptor+UserRecordFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5558FD4200225680066386B /* NSAppleEventDescriptor+UserRecordFields.swift */; };
 		D5558FD9200228D30066386B /* AppleEventUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5558FD7200228B80066386B /* AppleEventUtils.swift */; };
 		D57BE6E0204CD35F00D11AAC /* NSScriptCommand+Evergreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57BE6DF204CD35F00D11AAC /* NSScriptCommand+Evergreen.swift */; };
+		D57BE7642051025E00D11AAC /* testFeedExists.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D57BE7562051025E00D11AAC /* testFeedExists.applescript */; };
+		D57BE7652051027D00D11AAC /* testFeedExists.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D57BE7562051025E00D11AAC /* testFeedExists.applescript */; };
 		D5907CA0200232A1005947E5 /* testGenericScript.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5907C9D20023249005947E5 /* testGenericScript.applescript */; };
 		D5907CA1200232A1005947E5 /* testGetURL.applescript in Sources */ = {isa = PBXBuildFile; fileRef = D5558FD1200223F60066386B /* testGetURL.applescript */; };
 		D5907CA2200232AD005947E5 /* testGenericScript.applescript in CopyFiles */ = {isa = PBXBuildFile; fileRef = D5907C9D20023249005947E5 /* testGenericScript.applescript */; };
@@ -483,6 +485,7 @@
 			dstPath = TestScripts;
 			dstSubfolderSpec = 7;
 			files = (
+				D57BE7652051027D00D11AAC /* testFeedExists.applescript in CopyFiles */,
 				D5D07B19204B423C0093F739 /* testIterativeCreateAndDeleteFeed.applescript in CopyFiles */,
 				D5E4CCDE20303A66009B4FFC /* testCurrentArticleIsNil.applescript in CopyFiles */,
 				D5E4CCDF20303A66009B4FFC /* testURLsOfCurrentArticle.applescript in CopyFiles */,
@@ -665,6 +668,7 @@
 		D5558FD4200225680066386B /* NSAppleEventDescriptor+UserRecordFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSAppleEventDescriptor+UserRecordFields.swift"; path = "AppleEvents/NSAppleEventDescriptor+UserRecordFields.swift"; sourceTree = SOURCE_ROOT; };
 		D5558FD7200228B80066386B /* AppleEventUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleEventUtils.swift; sourceTree = "<group>"; };
 		D57BE6DF204CD35F00D11AAC /* NSScriptCommand+Evergreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScriptCommand+Evergreen.swift"; sourceTree = "<group>"; };
+		D57BE7562051025E00D11AAC /* testFeedExists.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testFeedExists.applescript; sourceTree = "<group>"; };
 		D5907C9D20023249005947E5 /* testGenericScript.applescript */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.applescript; path = testGenericScript.applescript; sourceTree = "<group>"; };
 		D5907CDC2002F0BE005947E5 /* Evergreen_project_release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Evergreen_project_release.xcconfig; sourceTree = "<group>"; };
 		D5907CDD2002F0BE005947E5 /* Evergreen_project_debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Evergreen_project_debug.xcconfig; sourceTree = "<group>"; };
@@ -1325,6 +1329,7 @@
 				D5E4CCD620303823009B4FFC /* selectAFeed.applescript */,
 				D5E4CCD520303823009B4FFC /* selectAnArticle.applescript */,
 				D5907C9D20023249005947E5 /* testGenericScript.applescript */,
+				D57BE7562051025E00D11AAC /* testFeedExists.applescript */,
 				D5A267B220131B8300A8D3C0 /* testFeedOPML.applescript */,
 				D5558FD1200223F60066386B /* testGetURL.applescript */,
 				D5F4EDE720075C1800B9E363 /* testNameAndUrlOfEveryFeed.applescript */,
@@ -1993,6 +1998,7 @@
 				D5F4EDE620075C1300B9E363 /* testNameOfEveryFolder.applescript in Sources */,
 				D5E4CCD720303823009B4FFC /* selectAnArticle.applescript in Sources */,
 				D5E4CCD820303823009B4FFC /* selectAFeed.applescript in Sources */,
+				D57BE7642051025E00D11AAC /* testFeedExists.applescript in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Evergreen/Info.plist
+++ b/Evergreen/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0d42</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>RSS Feed</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>feed</string>
+            </array>
+        </dict>
+    </array>
 	<key>CFBundleVersion</key>
 	<string>522</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Evergreen/Scriptability/Account+Scriptability.swift
+++ b/Evergreen/Scriptability/Account+Scriptability.swift
@@ -36,7 +36,7 @@ class ScriptableAccount: NSObject, UniqueIdScriptingObject, ScriptingObjectConta
     
     // I am not sure if account should prefer to be specified by name or by ID
     // but in either case it seems like the accountID would be used as the keydata, so I chose ID
-    
+    @objc(uniqueId)
     var scriptingUniqueId:Any {
         return account.accountID
     }

--- a/Evergreen/Scriptability/Article+Scriptability.swift
+++ b/Evergreen/Scriptability/Article+Scriptability.swift
@@ -38,6 +38,7 @@ class ScriptableArticle: NSObject, UniqueIdScriptingObject, ScriptingObjectConta
     // articles have id in the Evergreen database and id in the feed
     // article.uniqueID here is the feed unique id
 
+    @objc(uniqueId)
     var scriptingUniqueId:Any {
         return article.uniqueID
     }
@@ -67,11 +68,6 @@ class ScriptableArticle: NSObject, UniqueIdScriptingObject, ScriptingObjectConta
     @objc(externalUrl)
     var externalUrl:String?  {
         return article.externalURL
-    }
-
-    @objc(uniqueId)
-    var uniqueId:String  {
-        return article.uniqueID
     }
     
     @objc(title)

--- a/Evergreen/Scriptability/Author+Scriptability.swift
+++ b/Evergreen/Scriptability/Author+Scriptability.swift
@@ -38,6 +38,7 @@ class ScriptableAuthor: NSObject, UniqueIdScriptingObject {
     // I am not sure if account should prefer to be specified by name or by ID
     // but in either case it seems like the accountID would be used as the keydata, so I chose ID
 
+    @objc(uniqueId)
     var scriptingUniqueId:Any {
         return author.authorID
     }
@@ -47,11 +48,6 @@ class ScriptableAuthor: NSObject, UniqueIdScriptingObject {
     @objc(url)
     var url:String  {
         return self.author.url ?? ""
-    }
-    
-    @objc(uniqueId)
-    var uniqueId:String  {
-        return self.author.authorID
     }
     
     @objc(name)

--- a/Evergreen/Scriptability/Feed+Scriptability.swift
+++ b/Evergreen/Scriptability/Feed+Scriptability.swift
@@ -43,7 +43,7 @@ class ScriptableFeed: NSObject, UniqueIdScriptingObject, ScriptingObjectContaine
 
     // I am not sure if account should prefer to be specified by name or by ID
     // but in either case it seems like the accountID would be used as the keydata, so I chose ID
-
+    @objc(uniqueId)
     var scriptingUniqueId:Any {
         return feed.feedID
     }
@@ -139,11 +139,6 @@ class ScriptableFeed: NSObject, UniqueIdScriptingObject, ScriptingObjectContaine
     @objc(url)
     var url:String  {
         return self.feed.url
-    }
-    
-    @objc(uniqueId)
-    var uniqueId:String  {
-        return self.feed.feedID
     }
     
     @objc(name)

--- a/Evergreen/Scriptability/Folder+Scriptability.swift
+++ b/Evergreen/Scriptability/Folder+Scriptability.swift
@@ -39,6 +39,7 @@ class ScriptableFolder: NSObject, UniqueIdScriptingObject, ScriptingObjectContai
     // I am not sure if account should prefer to be specified by name or by ID
     // but in either case it seems like the accountID would be used as the keydata, so I chose ID
 
+    @objc(uniqueId)
     var scriptingUniqueId:Any {
         return folder.folderID
     }
@@ -96,11 +97,6 @@ class ScriptableFolder: NSObject, UniqueIdScriptingObject, ScriptingObjectContai
     }
 
     // MARK: --- Scriptable properties ---
-    
-    @objc(uniqueId)
-    var uniqueId:Int  {
-        return self.folder.folderID
-    }
     
     @objc(name)
     var name:String  {

--- a/EvergreenTests/ScriptingTests/ScriptingTests.swift
+++ b/EvergreenTests/ScriptingTests/ScriptingTests.swift
@@ -48,6 +48,10 @@ class ScriptingTests: AppleScriptXCTestCase {
         _ = doIndividualScript(filename: "testNameOfAuthors")
     }
     
+    func testFeedExists() {
+        _ = doIndividualScript(filename: "testFeedExists")
+    }
+    
     func testFeedOPML() {
         _ = doIndividualScript(filename: "testFeedOPML")
     }

--- a/EvergreenTests/ScriptingTests/scripts/testFeedExists.applescript
+++ b/EvergreenTests/ScriptingTests/scripts/testFeedExists.applescript
@@ -1,0 +1,10 @@
+-- this script just tests that no error was generated from the script
+try
+	tell application "Evergreen"
+		 exists feed 1 of account 1
+	end tell
+on error message
+	return {test_result:false, script_result:message}
+end try
+
+return {test_result:true}

--- a/Frameworks/RSCore/RSCore/NSString+RSCore.m
+++ b/Frameworks/RSCore/RSCore/NSString+RSCore.m
@@ -129,20 +129,41 @@ NSString *RSStringReplaceAll(NSString *stringToSearch, NSString *searchFor, NSSt
 	return self;
 }
 
+/*
+   given a URL that could be prefixed with 'feed:' or 'feeds:',
+   convert it to a URL that begins with 'http:' or 'https:'
+ 
+   Note: must handle edge case (like boingboing.net) where the feed URL is feed:http://boingboing.net/feed
+ 
+   Strategy:
+     1) note whether or not this is a feed: or feeds: or other prefix
+     2) strip the feed: or feeds: prefix
+     3) if the resulting string is not prefixed with http: or https:, then add http:// as a prefix
+ 
+*/
 - (NSString *)rs_normalizedURLString {
 	
 	NSString *s = [self rs_stringByTrimmingWhitespace];
 	
 	static NSString *feedPrefix = @"feed:";
 	static NSString *feedsPrefix = @"feeds:";
-	static NSString *httpPrefix = @"http:";
-	static NSString *httpsPrefix = @"https:";
+	static NSString *httpPrefix = @"http";
+	static NSString *httpsPrefix = @"https";
+	Boolean wasFeeds = false;
+ 
+    NSString *lowercaseS = [s lowercaseString];
+    if ([lowercaseS hasPrefix:feedPrefix] || [lowercaseS hasPrefix:feedsPrefix]) {
+        if ([lowercaseS hasPrefix:feedsPrefix]) {
+            wasFeeds = true;
+            s = [s rs_stringByStrippingPrefix:feedsPrefix caseSensitive:NO];
+        } else {
+            s = [s rs_stringByStrippingPrefix:feedPrefix caseSensitive:NO];
+        }
+    }
 	
-	s = [s rs_stringByReplacingPrefix:feedPrefix withHTTPPrefix:httpPrefix];
-	s = [s rs_stringByReplacingPrefix:feedsPrefix withHTTPPrefix:httpsPrefix];
-	
-	if (![s hasPrefix:@"http"]) {
-		s = [NSString stringWithFormat:@"http://%@", s];
+    lowercaseS = [s lowercaseString];
+	if (![lowercaseS hasPrefix:httpPrefix]) {
+		s = [NSString stringWithFormat: @"%@://%@", wasFeeds ? httpsPrefix : httpPrefix, s];
 	}
 	
 	return s;


### PR DESCRIPTION
Defining a CFBundleURLTypes in the Info.plist allows Evergreen to handle clicking on a feed: link in a browser

rs_normalizedURLString  didn't handle links like  "feed:http://boingboing.net/feed " very well, producing normalized urls like  http://:http://boingboing.net/feed  This provides a fix.

testFeedExistsScript is a very simple test script

Lastly, there was redundant code with uniqueId() and scriptingUniqueId() functions performing identical tasks -- the redundancy can be removed.
